### PR TITLE
siteconfig permissions are now compatible with ModelBackend

### DIFF
--- a/frog/views/siteconfig.py
+++ b/frog/views/siteconfig.py
@@ -33,7 +33,7 @@ from frog.uploader import handle_uploaded_file
 
 
 @login_required
-@permission_required('siteconfig.can_change')
+@permission_required('frog.change_siteconfig')
 @require_http_methods(["GET", "POST"])
 def index(request):
     if request.method == "GET":

--- a/frog/views/siteconfig.py
+++ b/frog/views/siteconfig.py
@@ -33,7 +33,6 @@ from frog.uploader import handle_uploaded_file
 
 
 @login_required
-@permission_required('frog.change_siteconfig')
 @require_http_methods(["GET", "POST"])
 def index(request):
     if request.method == "GET":
@@ -42,6 +41,7 @@ def index(request):
         return post(request)
 
 
+@permission_required('frog.view_siteconfig')
 def get(request):
     res = Result()
     res.append(SiteConfig.getSiteConfig().json())
@@ -49,6 +49,7 @@ def get(request):
     return JsonResponse(res.asDict())
 
 
+@permission_required('frog.change_siteconfig')
 def post(request):
     res = Result()
     config = SiteConfig.getSiteConfig()


### PR DESCRIPTION
* Not sure where causal breaking change was
    * Looks like it worked with SimpleAuth
    * Looks like it worked with older django versions
    * Looks like older versions of frog_ng were resilient to this error
    * However, was always getting persmission denied in new versions
* permission codename retrieved by:
    * Creating default frog setup
    * python3 manage.py dumpdata > dummy.json
    * finding "Can change site config"
        * "codename": "change_siteconfig"
* This causes siteconfig queries to return proper data
* This resolves an issue where galleries would not show up in newer versions for frog_ng