### PR TITLE
video processing now looks for files in MEDIA_ROOT

### DIFF
--- a/frog/models.py
+++ b/frog/models.py
@@ -501,7 +501,7 @@ class Video(Piece):
             FROG_FFPROBE,
             '-select_streams', 'v:0', '-show_entries', 'stream=width,height,codec_name,duration,avg_frame_rate',
             '-of', 'json',
-            self.source.file.name
+            Path(getRoot()) / self.source.file.name
         ]
         try:
             output = subprocess.check_output(cmd)

--- a/frog/models.py
+++ b/frog/models.py
@@ -501,7 +501,7 @@ class Video(Piece):
             FROG_FFPROBE,
             '-select_streams', 'v:0', '-show_entries', 'stream=width,height,codec_name,duration,avg_frame_rate',
             '-of', 'json',
-            Path(getRoot()) / self.source.file.name
+            getRoot() / self.source.file.name
         ]
         try:
             output = subprocess.check_output(cmd)


### PR DESCRIPTION
* previously would look for ID path in CWD.
* Would also work for null media roots
* MEDIA_ROOT is stripped out of the name when source is set